### PR TITLE
fix: synchronizepersoon

### DIFF
--- a/src/main/configurations/subscription-management-and-processing/Configuration_BrpPersonenSynchronizePersoon.xml
+++ b/src/main/configurations/subscription-management-and-processing/Configuration_BrpPersonenSynchronizePersoon.xml
@@ -47,18 +47,12 @@
             throwException="true">
         </Json2XmlValidatorPipe>
 
-        <SenderPipe name="GetPersoon" storeResultInSessionKey="newJSON" maxRetries="3" retryMinInterval="60" retryMaxInterval="240">
+        <SenderPipe name="GetPersoon" storeResultInSessionKey="newJSON"
+                    maxRetries="3" retryMinInterval="60" retryMaxInterval="240">
             <IbisLocalSender name="GetPersoonSender" javaListener="BrpPbOutwayListener" />
-            <Forward name="success" path="persoonOld2xml" />
+            <Forward name="success" path="JsonComparator" />
             <Forward name="exception" path="BadRequest" />
         </SenderPipe>
-
-        <JsonPipe name="persoonOld2xml" />
-
-        <PutInSessionPipe
-            name="storeBsnInSession">
-            <Param name="burgerservicenummer" xpathExpression='//burgerservicenummer/text()' />
-        </PutInSessionPipe>
 
         <!-- returns true if it's a subset, else returns a combined json version that can be
         immediately put in the database-->


### PR DESCRIPTION
problem: when you put a bsn into synchPersoon that does not exist, the getpersoon call will return an empty object, but now that breaks the system, while it shouldn't