### PR TITLE
fix: look for inp.bsn tag in incoming message to fix missing bsn

### DIFF
--- a/src/main/configurations/shadow/Configuration_ShadowReceiver.xml
+++ b/src/main/configurations/shadow/Configuration_ShadowReceiver.xml
@@ -8,7 +8,7 @@
 
         <PutInSessionPipe name="ExtractIncomingNotificationData" preserveInput="true">
             <Param name="appId" xpathExpression="npsLk01/stuurgegevens/ontvanger/applicatie" />
-            <Param name="bsn" xpathExpression="npsLk01/antwoord/object/inp.bsn" />
+            <Param name="bsn" xpathExpression="(//*[local-name()='inp.bsn'])[1]/text()" />
         </PutInSessionPipe>
 
         <SenderPipe name="storeMessage">


### PR DESCRIPTION
Use a different xpath expression to look for a bsn in the incoming message to avoid empty bsn columns in the shadowmessages table.