### PR TITLE
fix:  endpoint definition

### DIFF
--- a/src/main/configurations/brp-personen-bevragen-outway/DeploymentSpecifics.properties
+++ b/src/main/configurations/brp-personen-bevragen-outway/DeploymentSpecifics.properties
@@ -7,17 +7,13 @@
 # suppress warning keys
 warnings.suppress.defaultvalue=true
 
-
-# environment options: production, staging, test
-environment=test
-
 # Public brp endpoint
 endpoint.brp.public.test=https://proefomgeving.haalcentraal.nl/haalcentraal/api/brp/personen
 
 # Diginet endpoints
 endpoint.brp.diginet=${endpoint.brp.diginet.${environment}}
 oauth.token.url=https://auth.idm.diginetwerk.net/nidp/oauth/nam/token
-endpoint.brp.diginet.test=https://apigw.npr.idm.diginetwerk.net/lap/api/brp/personen
+endpoint.brp.diginet.staging=https://apigw.npr.idm.diginetwerk.net/lap/api/brp/personen
 endpoint.brp.diginet.production=https://apigw.idm.diginetwerk.net/api/brp/personen
 
 brp.oauth.enabled=${brp.${environment}.oauth.enabled}

--- a/src/main/resources/DeploymentSpecifics.properties
+++ b/src/main/resources/DeploymentSpecifics.properties
@@ -8,6 +8,9 @@ configurations.subscription-management-and-processing.classLoaderType=DirectoryC
 configurations.oauth.classLoaderType=DirectoryClassLoader
 configurations.shadow.classLoaderType=DirectoryClassLoader
 
+# environment options: production, staging, test
+environment=test
+
 # Disable output streaming (seems not to be disabled by default in 7.9-SNAPSHOT (in 7.8 it is))
 streaming.auto=false
 manageDatabase.webServiceListener.active=true


### PR DESCRIPTION
moves the environment property to the global property file.
updates the staging url property name