### PR TITLE
fix: remove quotes from SoapAction for parsing

### DIFF
--- a/src/main/configurations/subscription-management-and-processing/Configuration_EndpointRouter.xml
+++ b/src/main/configurations/subscription-management-and-processing/Configuration_EndpointRouter.xml
@@ -62,7 +62,7 @@
             <XsltPipe
                 name="LegalizeSoapActionForPipeName"
                 preserveInput="true"
-                xpathExpression="replace($Action, '/', '_')"
+                xpathExpression="replace(replace($Action, '&quot;', ''), '/', '_')"
                 storeResultInSessionKey="LegalizedSoapAction"
                 >
                 <Param name="Action" sessionKey="SOAPAction"/>


### PR DESCRIPTION
Removes `"` characters from incoming SOAPAction before parsing the value.