### PR TITLE
property to disable shadow database sender, when callback is enabled

### DIFF
--- a/src/main/configurations/subscription-management-and-processing/Configuration_BrpPersonenCallbackSender.xml
+++ b/src/main/configurations/subscription-management-and-processing/Configuration_BrpPersonenCallbackSender.xml
@@ -85,7 +85,7 @@
 				<Param name="url" xpathExpression="root/app/url" />
 			</PutInSessionPipe>
 
-			<SenderPipe name="SendMessageToShadowdb">
+			<SenderPipe name="SendMessageToShadowdb" active="!${enableCallback}">
 				<FixedQuerySender name="storeCallbackMessage" query="INSERT INTO shadowmessages (message, app_id, bsn, is_frank, timestamp) VALUES (?, ?, ?, True, CURRENT_TIMESTAMP)">
 					<Param name="message" sessionKey="soapMessage" type="BINARY" />
 					<Param name="appId" xpathExpression="root/app/applicatie" sessionKey="FilteredApplication" />


### PR DESCRIPTION
Disables the insert to the shadow database when callback property is enabled.
Allows callback messages to be sent to the callback endpoints, when the property is enabled