### PR TITLE
fix: add envelope around callback message

### DIFF
--- a/src/main/configurations/subscription-management-and-processing/Configuration_BrpPersonenCallbackSender.xml
+++ b/src/main/configurations/subscription-management-and-processing/Configuration_BrpPersonenCallbackSender.xml
@@ -118,6 +118,10 @@
 				<Forward name="exception" path="EXCEPTION" />
 			</XsltPipe>
 
+			<SoapWrapperPipe name="WrapResponse" getInputFromSessionKey="soapMessage" storeResultInSessionKey="soapMessage">
+				<Forward name="success" path="EXIT"/>
+			</SoapWrapperPipe>
+
 			<PutInSessionPipe name="ExtractUrl" getInputFromSessionKey="FilteredApplication">
 				<Param name="url" xpathExpression="root/app/url" />
 			</PutInSessionPipe>


### PR DESCRIPTION
adds a soapwrapper pipe to the callback pipeline to make sure the message is inside an envelope element