### PR TITLE
fix: update callback mutatiesoort from 'W' to 'T'

### DIFF
--- a/src/main/configurations/subscription-management-and-processing/Configuration_BrpPersonenCallbackSender.xml
+++ b/src/main/configurations/subscription-management-and-processing/Configuration_BrpPersonenCallbackSender.xml
@@ -109,7 +109,7 @@
 				<Param name="gebruiker" xpathExpression="/root/gebruiker"/>
 				<Param name="administratie" xpathExpression="/root/administratie"/>
 				<Param name="referentienummer" pattern="{uuid}"/>
-				<Param name="mutatiesoort" xpathExpression="/root/mutatiesoort"/>
+				<Param name="mutatiesoort" value="T"/>
 				<Param name="sleutelVerzendend" sessionKey="persoonssleutel"/>
 				<Param name="sleutelOntvangend" xpathExpression="/root/afnemersSleutel"/>
 				<Param name="varZenderApplicatie" xpathExpression="/root/applicationId"/>

--- a/src/main/configurations/subscription-management-and-processing/Configuration_BrpPersonenUpdateAndNotify.xml
+++ b/src/main/configurations/subscription-management-and-processing/Configuration_BrpPersonenUpdateAndNotify.xml
@@ -55,7 +55,7 @@
                     <Param name="ApplicationId" xpathExpression="//field[@name='APP_ID']/text()" />
                     <Param name="afnemersSleutel" xpathExpression="//field[@name='AFNEMERS_SLEUTEL']/text()" />
                     <Param name="persoonsSleutel" xpathExpression="//field[@name='PERSOONS_SLEUTEL']/text()" />
-                    <Param name="mutatiesoort" value="W" />
+                    <Param name="mutatiesoort" value="T" />
                 </IbisLocalSender>
                 <Forward name="success" path="EchoSuccess" />
                 <Forward name="exception" path="EXCEPTION" />

--- a/src/test/testtool/subscription-management-and-processing/subscripties/05/requestTestEnvOut.json
+++ b/src/test/testtool/subscription-management-and-processing/subscripties/05/requestTestEnvOut.json
@@ -1,6 +1,6 @@
 {
     "applicationId": "LBA",
-    "mutatiesoort": "W",
+    "mutatiesoort": "T",
     "gebruiker": null,
     "administratie": null,
     "afnemersSleutel": "12349876",

--- a/src/test/testtool/subscription-management-and-processing/subscripties/05/task.json
+++ b/src/test/testtool/subscription-management-and-processing/subscripties/05/task.json
@@ -1,6 +1,6 @@
 {
     "applicationId": "LBA",
-    "mutatiesoort": "W",
+    "mutatiesoort": "T",
     "gebruiker": null,
     "administratie": null,
     "afnemersSleutel": "12349876",

--- a/src/test/testtool/subscription-management-and-processing/subscripties/06/requestTestEnvOut.json
+++ b/src/test/testtool/subscription-management-and-processing/subscripties/06/requestTestEnvOut.json
@@ -1,6 +1,6 @@
 {
     "applicationId": "LBA",
-    "mutatiesoort": "W",
+    "mutatiesoort": "T",
     "gebruiker": null,
     "administratie": null,
     "afnemersSleutel": "12349876",

--- a/src/test/testtool/subscription-management-and-processing/subscripties/06/task.json
+++ b/src/test/testtool/subscription-management-and-processing/subscripties/06/task.json
@@ -1,6 +1,6 @@
 {
     "applicationId": "LBA",
-    "mutatiesoort": "W",
+    "mutatiesoort": "T",
     "gebruiker": null,
     "administratie": null,
     "afnemersSleutel": "LBA-001",

--- a/src/test/testtool/subscription-management-and-processing/subscripties/06/task2.json
+++ b/src/test/testtool/subscription-management-and-processing/subscripties/06/task2.json
@@ -1,6 +1,6 @@
 {
     "applicationId": "DEC_ZKN",
-    "mutatiesoort": "W",
+    "mutatiesoort": "T",
     "gebruiker": null,
     "administratie": null,
     "afnemersSleutel": "DEC-KEY-002",


### PR DESCRIPTION
updated the callback messages to send mutatiesoort T, since the body of the message does not contain an old and new entity. Instead only the new entity is sent as callback message.